### PR TITLE
🔖 0.7.1 [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # CHANGELOG
 
+## [v0.7.1](https://github.com/rdeville/test/compare/0.7.0...0.7.1) (2023-01-22)
+
+### Patch
+
+  * [`3be58bc`](https://github.com/rdeville/test/commit/3be58bc) 🔧 Update pre-commit config 
+  * [`b8063b2`](https://github.com/rdeville/test/commit/b8063b2) 🔧 Update template for semantic release 
+  * [`8dbed8a`](https://github.com/rdeville/test/commit/8dbed8a) 🔧 Update pre-commit 
+
+### Others
+
+  * [`081f268`](https://github.com/rdeville/test/commit/081f268) 💚 Fix semantic release template 
+  * [`7e1edde`](https://github.com/rdeville/test/commit/7e1edde) 💚 Fix CI env variable 
+  * [`e672016`](https://github.com/rdeville/test/commit/e672016) 💚 Fix ENV var use in CI release 
+  * [`15f632a`](https://github.com/rdeville/test/commit/15f632a) 💚 Fix env var in release CI 
+  * [`f9e7ad1`](https://github.com/rdeville/test/commit/f9e7ad1) 💚 Fix CI env variable 
+  * [`3534774`](https://github.com/rdeville/test/commit/3534774) 💚 Fix CI 
+  * [`65a7a1a`](https://github.com/rdeville/test/commit/65a7a1a) 💚 Fix CI 
+  * [`fac3ba5`](https://github.com/rdeville/test/commit/fac3ba5) 💚 Fix CI 
+  * [`8a6c366`](https://github.com/rdeville/test/commit/8a6c366) 💚 Fix CI 
+  * [`1de93b0`](https://github.com/rdeville/test/commit/1de93b0) 💚 Fix CI 
+  * [`424625f`](https://github.com/rdeville/test/commit/424625f) 🔇 Remove log output from releaserc config
+
 ## [v0.7.0](https://github.com/rdeville/test/compare/0.6.0...0.7.0) (2023-01-22)
 
 ### Minor


### PR DESCRIPTION
## [v0.7.1](https://github.com/rdeville/test/compare/0.7.0...0.7.1) (2023-01-22)

### Patch

  * [`3be58bc`](https://github.com/rdeville/test/commit/3be58bc) 🔧 Update pre-commit config
  * [`b8063b2`](https://github.com/rdeville/test/commit/b8063b2) 🔧 Update template for semantic release
  * [`8dbed8a`](https://github.com/rdeville/test/commit/8dbed8a) 🔧 Update pre-commit

### Others

  * [`081f268`](https://github.com/rdeville/test/commit/081f268) 💚 Fix semantic release template
  * [`7e1edde`](https://github.com/rdeville/test/commit/7e1edde) 💚 Fix CI env variable
  * [`e672016`](https://github.com/rdeville/test/commit/e672016) 💚 Fix ENV var use in CI release
  * [`15f632a`](https://github.com/rdeville/test/commit/15f632a) 💚 Fix env var in release CI
  * [`f9e7ad1`](https://github.com/rdeville/test/commit/f9e7ad1) 💚 Fix CI env variable
  * [`3534774`](https://github.com/rdeville/test/commit/3534774) 💚 Fix CI
  * [`65a7a1a`](https://github.com/rdeville/test/commit/65a7a1a) 💚 Fix CI
  * [`fac3ba5`](https://github.com/rdeville/test/commit/fac3ba5) 💚 Fix CI
  * [`8a6c366`](https://github.com/rdeville/test/commit/8a6c366) 💚 Fix CI
  * [`1de93b0`](https://github.com/rdeville/test/commit/1de93b0) 💚 Fix CI
  * [`424625f`](https://github.com/rdeville/test/commit/424625f) 🔇 Remove log output from releaserc config